### PR TITLE
Fix BlockchainAgent init, clean submodule

### DIFF
--- a/src/defi_abm/agents/blockchain.py
+++ b/src/defi_abm/agents/blockchain.py
@@ -88,7 +88,13 @@ class BlockchainAgent(Agent):
             "tx_executed": 0,
             "total_fees_collected": 0.0,
             "blocks": [],
+            "base_gas_price": float(base_gas_price),
         }
+
+        if initial_native_balance > 0:
+            # Allow the blockchain itself to hold a balance for paying refunds
+            # or other native transfers.
+            self.native_balances[self] = float(initial_native_balance)
 
     def create_account(self, address: Any, initial_balance: Optional[float] = None) -> None:
         """Register a new account with optional initial native token balance."""

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -608,6 +608,18 @@ def test_blockchain_basic_account_and_transfer():
     assert bc.get_metrics()["total_fees_collected"] == pytest.approx(21000.0)
 
 
+def test_blockchain_initialization_sets_config_values():
+    m = Model()
+    bc = BlockchainAgent(model=m, block_time=1.0, confirmations=1,
+                         base_gas_price=5.0, initial_native_balance=10.0)
+
+    # base gas price should be stored in metrics for later default use
+    assert bc.get_metrics()["base_gas_price"] == pytest.approx(5.0)
+
+    # the blockchain agent itself should have the configured initial balance
+    assert bc.get_native_balance(bc) == pytest.approx(10.0)
+
+
 # ----------------------------------------
 # BlockchainAgent Advanced Features Tests
 # ----------------------------------------


### PR DESCRIPTION
## Summary
- set initial base gas price in `BlockchainAgent` metrics
- optionally fund the blockchain agent with an initial native balance
- add regression test validating these settings
- remove accidentally added submodule directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fd7d883cc832b9b62661a65999adc