### PR TITLE
Remove unused Tuple import from LiquidatorAgent

### DIFF
--- a/src/defi_abm/agents/liquidator.py
+++ b/src/defi_abm/agents/liquidator.py
@@ -1,5 +1,5 @@
 from mesa import Agent
-from typing import Optional, Callable, List, Tuple
+from typing import Optional, Callable, List
 import logging
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- tidy LiquidatorAgent import list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68402b60f954832bb8e27b911d1a1054