### PR TITLE
Support multiple AMM configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ config = {
     "simulation": {"steps": 2},
     "protocols": {
         "oracle": {"mode": "static", "initial_price": 100.0},
-        "amm": {"token_x": "ETH", "token_y": "DAI", "reserve_x": 5.0, "reserve_y": 1000.0},
+        "amm": [{"token_x": "ETH", "token_y": "DAI", "reserve_x": 5.0, "reserve_y": 1000.0}],
         "lending": {"collateral_factor": 0.75, "agents": [{"collateral_token": "ETH", "borrow_token": "DAI", "collateral_amount": 1.0, "desired_ltv": 0.5}]},
     },
 }

--- a/examples/config_showcase.yaml
+++ b/examples/config_showcase.yaml
@@ -9,11 +9,11 @@ protocols:
     mode: csv
 
   amm:
-    token_x: "ETH"
-    token_y: "DAI"
-    reserve_x: 10.0
-    reserve_y: 20000.0
-    fee_rate: 0.003
+    - token_x: "ETH"
+      token_y: "DAI"
+      reserve_x: 10.0
+      reserve_y: 20000.0
+      fee_rate: 0.003
 
   lending:
     collateral_factor: 0.75

--- a/tests/test_amm.py
+++ b/tests/test_amm.py
@@ -5,6 +5,9 @@ from mesa import Model
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 import importlib
+for m in list(sys.modules):
+    if m.startswith("defi_abm"):
+        sys.modules.pop(m)
 import defi_abm
 importlib.reload(defi_abm)
 

--- a/tests/test_blockchain.py
+++ b/tests/test_blockchain.py
@@ -5,6 +5,9 @@ from mesa import Model
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 import importlib
+for m in list(sys.modules):
+    if m.startswith("defi_abm"):
+        sys.modules.pop(m)
 import defi_abm
 importlib.reload(defi_abm)
 

--- a/tests/test_lending.py
+++ b/tests/test_lending.py
@@ -5,6 +5,9 @@ from mesa import Model
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 import importlib
+for m in list(sys.modules):
+    if m.startswith("defi_abm"):
+        sys.modules.pop(m)
 import defi_abm
 importlib.reload(defi_abm)
 

--- a/tests/test_liquidator.py
+++ b/tests/test_liquidator.py
@@ -5,6 +5,9 @@ from mesa import Model
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 import importlib
+for m in list(sys.modules):
+    if m.startswith("defi_abm"):
+        sys.modules.pop(m)
 import defi_abm
 importlib.reload(defi_abm)
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -6,6 +6,9 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 import importlib
+for m in list(sys.modules):
+    if m.startswith("defi_abm"):
+        sys.modules.pop(m)
 import defi_abm
 importlib.reload(defi_abm)
 
@@ -26,7 +29,7 @@ def simple_config(tmp_path):
         "simulation": {"steps": 2, "seed": 123},
         "protocols": {
             "oracle": {"price_csv": price_csv_path, "initial_price": 100.0, "mode": "csv"},
-            "amm": {"token_x": "ETH", "token_y": "DAI", "reserve_x": 5.0, "reserve_y": 1000.0, "fee_rate": 0.0},
+            "amm": [{"token_x": "ETH", "token_y": "DAI", "reserve_x": 5.0, "reserve_y": 1000.0, "fee_rate": 0.0}],
             "lending": {
                 "collateral_factor": 0.75,
                 "interest_rate_apr": 0.0,

--- a/tests/test_oracle.py
+++ b/tests/test_oracle.py
@@ -6,6 +6,9 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 import importlib
+for m in list(sys.modules):
+    if m.startswith("defi_abm"):
+        sys.modules.pop(m)
 import defi_abm
 importlib.reload(defi_abm)
 


### PR DESCRIPTION
## Summary
- allow the DeFi model to accept a list of AMM configurations
- iterate over those configs to create pools and search them
- update example config and README
- fix tests to force re-import of local modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687636860ffc832b9d3ef988c6e32ec0